### PR TITLE
Add Turnstile verification to print endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # Receipt Printer
 
 a project i made to have people print images on my epson receipt printer. thought it was a cool idea, spent about 2 days researching the escpos libraries and then putting it fully into effect.
+
+## Turnstile
+
+Set the following environment variables:
+
+- `VITE_TURNSTILE_SITE_KEY` – client-side site key
+- `TURNSTILE_SECRET` – server-side secret key

--- a/api/status.js
+++ b/api/status.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+/* global process */
 export default async function handler(req, res) {
   if (req.method !== "GET") return res.status(405).send("Method Not Allowed")
 

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>chelk's receipt printer</title>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/hooks/useCanvasDrawing.js
+++ b/src/hooks/useCanvasDrawing.js
@@ -85,7 +85,8 @@ export function useCanvasDrawing(ref, { width = 250, height = 400, stroke = "#11
     e.preventDefault()
     const canvas = ref.current
     if (canvas && typeof canvas.setPointerCapture === "function") {
-      try { canvas.setPointerCapture(e.pointerId) } catch {}
+      try { canvas.setPointerCapture(e.pointerId) }
+      catch (err) { void err }
     }
     isDrawingRef.current = true
     lastPtRef.current = getRelativePoint(e)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,10 +1,11 @@
 const ENDPOINT = '/api/print'
 
-export async function sendPrint({ blob, name, signal }) {
+export async function sendPrint({ blob, name, token, signal }) {
   const form = new FormData()
   form.append("image", blob, "drawing.png")
   form.append("name", name)
-  const r = await fetch(ENDPOINT, { method: "POST", body: form, signal })
+  const headers = token ? { "cf-turnstile-response": token } : {}
+  const r = await fetch(ENDPOINT, { method: "POST", body: form, headers, signal })
   if (!r.ok) {
     const t = await r.text().catch(() => "")
     throw new Error(`Print failed: ${r.status} ${t}`)


### PR DESCRIPTION
## Summary
- Load Cloudflare Turnstile script and widget
- Capture Turnstile token on print submission and include it in API call
- Verify token server-side before proxying to printer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d5af2d20c8321b2cebfcc591a74dd